### PR TITLE
Potential fix for code scanning alert no. 19: Prototype-polluting assignment

### DIFF
--- a/mock-issueops/server.js
+++ b/mock-issueops/server.js
@@ -6,20 +6,21 @@ const bodyParser = require('body-parser');
 const app = express();
 app.use(bodyParser.json());
 
-let issues = {
-  "123": { id: "123", status: "Open", deployment_env: null, package: null }
-};
+// Use a Map to avoid prototype pollution
+let issues = new Map([
+  ["123", { id: "123", status: "Open", deployment_env: null, package: null }]
+]);
 
 // Get issue by ID
 app.get('/issues/:id', (req, res) => {
-  const issue = issues[req.params.id];
+  const issue = issues.get(req.params.id);
   if (issue) res.json(issue);
   else res.status(404).json({ error: 'Issue not found' });
 });
 
 // Update issue by ID
 app.patch('/issues/:id', (req, res) => {
-  const issue = issues[req.params.id];
+  const issue = issues.get(req.params.id);
   if (!issue) return res.status(404).json({ error: 'Issue not found' });
 
   const { status, deployment_env, package: pkg } = req.body;
@@ -27,7 +28,7 @@ app.patch('/issues/:id', (req, res) => {
   if (deployment_env) issue.deployment_env = deployment_env;
   if (pkg) issue.package = pkg;
 
-  issues[req.params.id] = issue;
+  issues.set(req.params.id, issue);
   res.json(issue);
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/19](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/19)

The best way to fix the problem is to use a data structure for `issues` that is not susceptible to prototype pollution. Replace the plain object with a `Map`, which treats keys as values and does not interpret special property names like `__proto__` or `constructor`. Refactor all code that reads from or writes to `issues` to use `Map` methods (`get`, `set`, `has`) instead of bracket notation. Specifically, change:
- Initialization to use `new Map()` with an initial value.
- All `issues[req.params.id]` accesses to `issues.get(req.params.id)`.
- All assignments such as `issues[req.params.id] = issue` to `issues.set(req.params.id, issue)`.

You may need to adjust how the mock issue is initially loaded into the `Map`. Also, keep the logic functionally identical for the rest of the code, but ensure all issue lookups and updates are via `Map` methods, not object property access.

No extra methods or helpers are needed; only the standard `Map` and slightly adjusted code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
