### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: XLDeploy Sequential Pipeline
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/16](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/16)

To fix the issue, add a `permissions` block to the workflow file `.github/workflows/deploy.yml` at the root level (just after the `name:` and before the `on:` block). The safest default is to grant only `contents: read`, which suffices for most workflows that only need to check out repository files and do not need to modify code, issues, or pull requests. If any job or step requires more (e.g., creating releases, updating pull requests, or opening issues), those jobs should get additional permissions at their job-level `permissions` block. For now, add:

```yaml
permissions:
  contents: read
```

at the top-level of the workflow, just after the `name:` key and before `on:`. This change does not affect any workflow functionality as currently written.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
