### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/13](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/13)

The best way to fix the problem is to explicitly add a `permissions` key at either the workflow or job level, restricting the permissions to only what the workflow requires for its tasks. In this case, based on standard use of the `release-drafter` action, the required permissions are `contents: read` (to read repository info and tags) and `pull-requests: write` (to create or update release drafts through pull request comments/labels). 

To ensure the least privilege, add the following block within the `update_release_draft` job (directly after the job name but before `runs-on`):

```yaml
permissions:
  contents: read
  pull-requests: write
```

Alternatively, for simplicity and futureproofing, this can be set at the root of the workflow, above `jobs:`.

For the shown code snippet, the required fix is to add the permissions block to the job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
