### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -1,4 +1,6 @@
 name: Matrix Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/7](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to limit the permissions of the workflow's GITHUB_TOKEN to the least required for the jobs performed. In this context, the workflow only checks out code and runs tests; it does not make changes to the repository, open issues, or interact with pull requests. Therefore, the only required permission is `contents: read`. You may add the `permissions: contents: read` block either at the top level (making it apply to all jobs), or within the individual job. In this case, it’s cleanest to add it just below the workflow name at the top level, so all jobs in the workflow are covered.

Change needed:  
- In `.github/workflows/matrix-tests.yml`, insert the following block after the `name` field and before the `on` trigger:

```yml
permissions:
  contents: read
```

No imports or further code changes are needed; just this single YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
