### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Semantic Release
+permissions:
+  contents: write
 
 on:
-  push:
     branches:
       - main
 


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/12](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/12)

To address the flagged issue, explicitly set a `permissions` block for this workflow to reduce the default token rights to the minimum necessary. Since `semantic-release` requires permission to read and write repository contents (creating tags, updating changelogs), and possibly to make releases and publish statuses, the recommended minimal permissions are:
- `contents: write` (for tags, changelogs, commits)
- `issues: write` and/or `pull-requests: write` (if semantic-release is configured to update issues/PRs)
- If using the GitHub release plugin: `packages: write` and/or `deployments: write`

However, for the majority of semantic-release setups, `contents: write` is the base requirement. To follow the principle of least privilege, start with `contents: write` at the workflow level, and expand for other permissions *if needed*.

This block should be added directly after the workflow `name:` and before the `on:` block (per GitHub syntax recommendations).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
