### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,7 @@
 name: Project Automation
+permissions:
+  issues: write
+  pull-requests: write
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/10](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/10)

To fix the problem, add an explicit `permissions` block to the workflow. Because the job uses a third-party action to manipulate project cards for issues and pull requests, it likely needs certain write permissions (at minimum, `issues: write` and `pull-requests: write`). Other permissions, such as `contents`, can be set to `read` or omitted unless required. The workflow-level `permissions` block can be inserted at the root, above (or below) the `on:` block, to apply to all jobs. Alternatively, a job-level block right under `runs-on:` can be used if only this job needs those permissions. In this case, specifying at the workflow root is better as a starting point. The change requires adding the block in `.github/workflows/project-automation.yml` without modifying the rest of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
