### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/6](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/6)

To fix the problem, we should add a `permissions` key specifying the minimal required privileges to the workflow or the specific job. Since the workflow only checks out code and runs static analysis tools and linters, it does not require any write or workflow-scoped permissions. The minimal required permission is typically `contents: read`. The key can be added at the job level under `lint:` (applies only to that job), or at the workflow root (applies to all jobs)—since there's only one job, either is fine, but job-scoped is often considered clearer. The change needed is to add the following block under `jobs.lint`:  
```yaml
permissions:
  contents: read
```

No additional packages, methods, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
