### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/4](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/4)

The best way to fix this problem is to add an explicit `permissions` block to the workflow. For a documentation deploy job using `mkdocs gh-deploy`, you typically only need write access to repository contents in order to push generated site files to the `gh-pages` branch. Therefore, at the top-level (applies to all jobs), or within the `deploy-docs` job, add:

```yaml
permissions:
  contents: write
```

This restricts the GITHUB_TOKEN so the workflow can only interact with repository contents (and only with write privileges, which are needed for deployment) and removes unnecessary privileges.

Edits are needed within `.github/workflows/docs.yml`, specifically above the `jobs:` block (for root-level application), or within the `deploy-docs` job itself (if you want to scope it more tightly). To minimize impact and follow best practices, add the block at the top-level, after the `name:` and before `on:` or immediately after `on:`.

No new imports, methods, or other definitions are needed—just the addition of the permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
