### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,6 @@
 name: Test Coverage
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/3](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/3)

The best fix is to add an explicit `permissions:` block to restrict the `GITHUB_TOKEN`'s capabilities to only what the workflow needs. As all steps only require reading repository contents (e.g., for checkout), uploading artifacts, and interacting with third-party services via secrets (not via the repository itself), `permissions: contents: read` is the minimal and correct restriction. 

This `permissions:` block can be placed at the workflow (top) level, so all jobs inherit the restriction, or at the job level. Placing it at the root just after the `name` and before `on:` is the broadest and recommended approach. You only need to add:

```yaml
permissions:
  contents: read
```
directly after the `name:` at the top of the file. No changes are needed to the jobs themselves.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
