### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/attach-release-notes.yml
+++ b/.github/workflows/attach-release-notes.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   attach-release-notes:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/2](https://github.com/kmcallorum/xldeploy_wrapper/security/code-scanning/2)

To fix this issue, we should add an explicit `permissions` block that grants the minimal necessary privileges for the workflow to function. Specifically, the `softprops/action-gh-release` action requires `contents: write` to update the release, but all other permissions should remain at their defaults (`none`). This permission should be set at the job level (within `attach-release-notes:` in line with the highlighted line), unless multiple jobs require it, in which case it could be set at the workflow root. Since this workflow only has one job, we will add the block under the job. No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
